### PR TITLE
Use @surma/rollup-plugin-off-main-thread

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "module": "./dist/index.js",
   "sideEffects": false,
   "scripts": {
-    "prebuild": "rimraf dist && rollup",
+    "prebuild": "rimraf dist",
     "build": "rollup -c",
     "prepare": "npm run build"
   },
@@ -44,6 +44,7 @@
     "@babel/preset-env": "7.8.6",
     "@babel/preset-react": "7.8.3",
     "@babel/register": "^7.8.6",
+    "@surma/rollup-plugin-off-main-thread": "^1.4.1",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.0.6",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,8 @@
 import path from 'path'
 import babel from 'rollup-plugin-babel'
 import resolve from 'rollup-plugin-node-resolve'
-import webWorkerLoader from 'rollup-plugin-web-worker-loader'
+import OMT from "@surma/rollup-plugin-off-main-thread";
+
 
 const external = ['react', 'react-three-fiber', 'three']
 const extensions = ['.js', '.jsx', '.ts', '.tsx', '.json']
@@ -10,23 +11,23 @@ const getBabelOptions = ({ useESModules }, targets) => ({
   babelrc: false,
   extensions,
   include: ['src/**/*', '**/node_modules/**'],
-  runtimeHelpers: true,
+  externalHelpers: true,
   presets: [['@babel/preset-env', { loose: true, modules: false, targets }], '@babel/preset-react'],
   plugins: [
-    ['transform-react-remove-prop-types', { removeImport: true }],
-    ['@babel/transform-runtime', { regenerator: false, useESModules }],
+    ['transform-react-remove-prop-types', { removeImport: true }]
   ],
 })
 
-export default [
-  {
-    input: `./src/index`,
-    output: { file: `dist/index.js`, format: 'esm' },
-    external,
-    plugins: [
-      resolve({ extensions }),
-      webWorkerLoader(),
-      babel(getBabelOptions({ useESModules: true }, '>1%, not dead, not ie 11, not op_mini all')),
-    ],
+export default {
+  input: './src/index',
+  output: {
+    dir: 'dist',
+    format: 'esm'
   },
-]
+  external,
+  plugins: [
+    resolve({ extensions }),
+    OMT(),
+    babel(getBabelOptions({ useESModules: true }, '>1%, not dead, not ie 11, not op_mini all')),
+  ],
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import { Object3D } from 'three'
 import React, { useState, useEffect, useContext, useRef, useMemo } from 'react'
 import { useFrame } from 'react-three-fiber'
-import CannonWorker from 'web-worker:../src/worker.js'
+import WORKER_URL from 'omt:./worker.js'
 
 const refs = {}
 const buffers = React.createRef()
@@ -17,7 +17,7 @@ export function Physics({ children }) {
     if (count) {
       let positions = new Float32Array(count * 3)
       let quaternions = new Float32Array(count * 4)
-      let currentWorker = new CannonWorker()
+      let currentWorker = new Worker(WORKER_URL)
 
       function loop() {
         if (positions.byteLength !== 0 && quaternions.byteLength !== 0) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -796,6 +796,14 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@surma/rollup-plugin-off-main-thread@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-1.4.1.tgz#bf1343e5a926e5a1da55e3affd761dda4ce143ef"
+  integrity sha512-ZPBWYQDdO4JZiTmTP3DABsHhIPA7bEJk9Znk7tZsrbPGanoGo8YxMv//WLx5Cvb+lRgS42+6yiOIYYHCKDmkpQ==
+  dependencies:
+    ejs "^2.6.1"
+    magic-string "^0.25.0"
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -1086,6 +1094,11 @@ define-properties@^1.1.2:
   integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
   dependencies:
     object-keys "^1.0.12"
+
+ejs@^2.6.1:
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.7.4.tgz#48661287573dcc53e366c7a1ae52c3a120eec9ba"
+  integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
 electron-to-chromium@^1.3.363:
   version "1.3.365"
@@ -1525,6 +1538,13 @@ loose-envify@^1.0.0:
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
+
+magic-string@^0.25.0:
+  version "0.25.6"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.6.tgz#5586387d1242f919c6d223579cc938bf1420795e"
+  integrity sha512-3a5LOMSGoCTH5rbqobC2HuDNRtE2glHZ8J7pK+QZYppyWA36yuNpsX994rIY2nCuyP7CZYy7lQq/X2jygiZ89g==
+  dependencies:
+    sourcemap-codec "^1.4.4"
 
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
@@ -1974,6 +1994,11 @@ source-map@^0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+sourcemap-codec@^1.4.4:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
+  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
 strip-final-newline@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This uses [rollup-plugin-off-main-thread](https://github.com/surma/rollup-plugin-off-main-thread) to bundle your worker cleanly via rollup without making it an explicit entry.

**TLDR:**

```js
import WORKER_URL from 'omt:./worker.js'
//...
let currentWorker = new Worker(WORKER_URL) // hashed and whatnot
```

Generates 2 bundles:

<img src="https://user-images.githubusercontent.com/105127/75787456-c1d70c00-5d34-11ea-8da2-96eb43b9184a.png" width="229">

**Note:** this _requires_ disabling code splitting, which is a good idea for this project anyway since it was only ever creating a tiny module for the `Object.assign()` polyfill.